### PR TITLE
Rename project references to be generic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
             platforms: 'linux/amd64'
             package: 'src'
-            name: 'convert2rhel-worker-${{ steps.tagName.outputs.tag }}'
+            name: 'rhc-bash-worker-${{ steps.tagName.outputs.tag }}'
             compress: 'true'
             dest: 'dist'
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 # Project constants
 VERSION ?= 0.1
-PKGNAME ?= convert2rhel-worker
+PKGNAME ?= rhc-bash-worker
 GO_SOURCES := $(wildcard src/*.go)
 PYTHON ?= python3
 PIP ?= pip3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Convert2RHEL Worker
+# RHC Bash Worker
 
-Experimental worker built for Convert2RHEL integration with Insights.
+Experimental worker built for Conversions & Migrations integration with Insights.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/r0x0d/convert2rhel-worker
+module github.com/r0x0d/rhc-bash-worker
 
 go 1.20
 

--- a/packaging/rhc-bash-worker.spec
+++ b/packaging/rhc-bash-worker.spec
@@ -1,0 +1,41 @@
+Name:           rhc-bash-worker
+Version:        0.1
+Release:        1%{?dist}
+Summary:        RHC bash worker
+
+License:
+URL:
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  golang
+Requires:       system-rpm-macros
+
+Provides:       %{name} = %{version}
+
+%description
+test
+
+%prep
+%autosetup
+
+
+%build
+CGO_ENABLED=0 go build -v -o %{name}
+
+%configure
+%make_build
+
+
+%install
+%make_install
+
+
+%files
+%license add-license-file-here
+%doc add-docs-here
+
+
+
+%changelog
+* Wed May 24 2023 r0x0d
+-

--- a/python/mqtt_publish.py
+++ b/python/mqtt_publish.py
@@ -29,7 +29,7 @@ def get_ip_address():
   return host_ip
 
 # This is changed everytime you refresh the box and register the machine again.
-CLIENT_ID = "a6f2bdbe-8b3b-49ee-b4cd-bc150a7809c6"
+CLIENT_ID = "a723a681-6e49-4660-a07a-56359a515675"
 BROKER = '127.0.0.1'
 BROKER_PORT = 1883
 TOPIC = f"yggdrasil/{CLIENT_ID}/data/in"
@@ -41,7 +41,7 @@ MESSAGE = {
   # "client_uuid": CLIENT_ID,
   "version": 1,
   "sent": "2021-01-12T14:58:13+00:00", # str(datetime.datetime.now().isoformat()),
-  "directive": 'convert2rhel',
+  "directive": 'rhc-bash-worker',
   "content": f'http://{get_ip_address()}:8000/python/command',
   "metadata": {
     "return_url": 'http://raw.example.com/return'

--- a/src/logger.go
+++ b/src/logger.go
@@ -8,8 +8,8 @@ import (
 	"git.sr.ht/~spc/go-log"
 )
 
-const logFolder string = "/var/log/convert2rhel"
-const fileName string = "convert2rhel-worker.log"
+const logFolder string = "/var/log/rhc-bash-worker"
+const fileName string = "rhc-bash-worker.log"
 
 func setupLogger() *os.File {
 	// Check if path exists, if not, create it.

--- a/src/main.go
+++ b/src/main.go
@@ -38,8 +38,8 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	// Register as a handler of the "convert2rhel" type.
-	r, err := c.Register(ctx, &pb.RegistrationRequest{Handler: "convert2rhel", Pid: int64(os.Getpid()), DetachedContent: true})
+	// Register as a handler of the "rhc-bash-worker" type.
+	r, err := c.Register(ctx, &pb.RegistrationRequest{Handler: "rhc-bash-worker", Pid: int64(os.Getpid()), DetachedContent: true})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/util.go
+++ b/src/util.go
@@ -2,23 +2,22 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"git.sr.ht/~spc/go-log"
 )
 
-const temporaryConvert2RHELDir string = "/var/lib/convert2rhel"
-
 func writeFileToTemporaryDir(data []byte) string {
+	const temporaryWorkerDirectory string = "/var/lib/rhc-bash-worker"
+
 	// Check if path exists, if not, create it.
-	if _, err := os.Stat(temporaryConvert2RHELDir); err != nil {
-		if err := os.Mkdir(temporaryConvert2RHELDir, os.ModePerm); err != nil {
+	if _, err := os.Stat(temporaryWorkerDirectory); err != nil {
+		if err := os.Mkdir(temporaryWorkerDirectory, os.ModePerm); err != nil {
 			log.Errorln(err)
 		}
 	}
 
-	file, err := os.CreateTemp(temporaryConvert2RHELDir, "c2r-worker-")
+	file, err := os.CreateTemp(temporaryWorkerDirectory, "c2r-worker-")
 	if err != nil {
 		log.Errorln(err)
 	}
@@ -33,7 +32,7 @@ func writeFileToTemporaryDir(data []byte) string {
 }
 
 func readOutputFile(filePath string) []byte {
-	output, err := ioutil.ReadFile(filePath)
+	output, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Errorln("Couldn't read file")
 	}


### PR DESCRIPTION
Since the worker could be potentially used for both Conversions and Migrations, the worker and its references were renamed to be generic.